### PR TITLE
chore: update workflow references

### DIFF
--- a/.github/workflows/pr_check_tests.yml
+++ b/.github/workflows/pr_check_tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/test_python_docker.yml@1.0.0
+    uses: epam/ai-dial-ci/.github/workflows/test_python_docker.yml@1.0.2
     with:
       bypass_checks: false
       python_version: 3.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,5 +9,5 @@ env:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/publish_python_docker.yml@1.0.0
+    uses: epam/ai-dial-ci/.github/workflows/publish_python_docker.yml@1.0.2
     secrets: inherit


### PR DESCRIPTION
This PR:
- fixes release notes generation for newly-created `release-*` branches