### PR TITLE
fix: fix handling of datetime with less than 3 fractional digits for seconds (#14)

### DIFF
--- a/aidial_analytics_realtime/app.py
+++ b/aidial_analytics_realtime/app.py
@@ -3,6 +3,7 @@ import logging
 import re
 from datetime import datetime, timezone
 
+import dateutil
 import uvicorn
 from fastapi import Depends, FastAPI, Request
 
@@ -173,7 +174,7 @@ async def on_log_message(
         response["upstream_uri"] if "upstream_uri" in response else ""
     )
 
-    timestamp = datetime.fromisoformat(request["time"])
+    timestamp = dateutil.parser.isoparse(request["time"])
     if timestamp.tzinfo is None:
         # The logs may come without the timezone information. We want it to be interpreted as UTC, not local time.
         timestamp = timestamp.replace(tzinfo=timezone.utc)

--- a/aidial_analytics_realtime/app.py
+++ b/aidial_analytics_realtime/app.py
@@ -3,7 +3,7 @@ import logging
 import re
 from datetime import datetime, timezone
 
-import dateutil
+import dateutil.parser as dateutil_parser
 import uvicorn
 from fastapi import Depends, FastAPI, Request
 
@@ -174,7 +174,7 @@ async def on_log_message(
         response["upstream_uri"] if "upstream_uri" in response else ""
     )
 
-    timestamp = dateutil.parser.isoparse(request["time"])
+    timestamp = dateutil_parser.isoparse(request["time"])
     if timestamp.tzinfo is None:
         # The logs may come without the timezone information. We want it to be interpreted as UTC, not local time.
         timestamp = timestamp.replace(tzinfo=timezone.utc)

--- a/aidial_analytics_realtime/app.py
+++ b/aidial_analytics_realtime/app.py
@@ -1,9 +1,8 @@
 import json
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import datetime
 
-import dateutil.parser as dateutil_parser
 import uvicorn
 from fastapi import Depends, FastAPI, Request
 
@@ -13,6 +12,7 @@ from aidial_analytics_realtime.influx_writer import (
     create_influx_writer,
 )
 from aidial_analytics_realtime.rates import RatesCalculator
+from aidial_analytics_realtime.time import parse_time
 from aidial_analytics_realtime.topic_model import TopicModel
 from aidial_analytics_realtime.universal_api_utils import merge
 
@@ -174,10 +174,7 @@ async def on_log_message(
         response["upstream_uri"] if "upstream_uri" in response else ""
     )
 
-    timestamp = dateutil_parser.isoparse(request["time"])
-    if timestamp.tzinfo is None:
-        # The logs may come without the timezone information. We want it to be interpreted as UTC, not local time.
-        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    timestamp = parse_time(request["time"])
 
     match = re.search(RATE_PATTERN, uri)
     if match:

--- a/aidial_analytics_realtime/time.py
+++ b/aidial_analytics_realtime/time.py
@@ -1,0 +1,11 @@
+from datetime import datetime, timezone
+
+import dateutil.parser as dateutil_parser
+
+
+def parse_time(time_string: str) -> datetime:
+    timestamp = dateutil_parser.isoparse(time_string)
+    if timestamp.tzinfo is None:
+        # The logs may come without the timezone information. We want it to be interpreted as UTC, not local time.
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,7 @@ nox.options.sessions = ["lint", "tests"]
 SRC = "."
 
 
-@nox.session
+@nox.session(python=["3.10"])
 def lint(session):
     """Runs linters and fixers"""
     session.run("poetry", "install", external=True)
@@ -17,7 +17,7 @@ def lint(session):
     session.run("pyright", SRC)
 
 
-@nox.session
+@nox.session(python=["3.10"])
 def format(session):
     """Runs linters and fixers"""
     session.run("poetry", "install", external=True)

--- a/poetry.lock
+++ b/poetry.lock
@@ -928,16 +928,6 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -1899,11 +1889,6 @@ files = [
     {file = "scikit_learn-1.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f66eddfda9d45dd6cadcd706b65669ce1df84b8549875691b1f403730bdef217"},
     {file = "scikit_learn-1.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6448c37741145b241eeac617028ba6ec2119e1339b1385c9720dae31367f2be"},
     {file = "scikit_learn-1.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:c413c2c850241998168bbb3bd1bb59ff03b1195a53864f0b80ab092071af6028"},
-    {file = "scikit_learn-1.3.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:ef540e09873e31569bc8b02c8a9f745ee04d8e1263255a15c9969f6f5caa627f"},
-    {file = "scikit_learn-1.3.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:9147a3a4df4d401e618713880be023e36109c85d8569b3bf5377e6cd3fecdeac"},
-    {file = "scikit_learn-1.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2cd3634695ad192bf71645702b3df498bd1e246fc2d529effdb45a06ab028b4"},
-    {file = "scikit_learn-1.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c275a06c5190c5ce00af0acbb61c06374087949f643ef32d355ece12c4db043"},
-    {file = "scikit_learn-1.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:0e1aa8f206d0de814b81b41d60c1ce31f7f2c7354597af38fae46d9c47c45122"},
     {file = "scikit_learn-1.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:52b77cc08bd555969ec5150788ed50276f5ef83abb72e6f469c5b91a0009bbca"},
     {file = "scikit_learn-1.3.1-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:a683394bc3f80b7c312c27f9b14ebea7766b1f0a34faf1a2e9158d80e860ec26"},
     {file = "scikit_learn-1.3.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a15d964d9eb181c79c190d3dbc2fff7338786bf017e9039571418a1d53dab236"},
@@ -2614,4 +2599,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10"
-content-hash = "7b8d3b8b4cf3040a180c98ee81bc51099ac8ca0cd64c2d653ddd4ff3d008d7e1"
+content-hash = "73239530c64cae0071f516fab32d05b839ed313084cd5a90547babb22c7d773e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ torch = {version = "^2.0.1+cpu", source = "pytorch"}
 bertopic = "^0.15.0"
 llvmlite = "^0.40.1"
 python-dotenv = "^1.0.0"
+python-dateutil = "^2.8.2"
 
 [[tool.poetry.source]]
 name = "pytorch"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -51,10 +51,44 @@ def test_data_request():
                         },
                     }
                 )
-            }
+            },
+            {
+                "message": json.dumps(
+                    {
+                        "apiType": "DialOpenAI",
+                        "chat": {"id": "chat-2"},
+                        "project": {"id": "PROJECT-KEY-2"},
+                        "user": {"id": "", "title": ""},
+                        "request": {
+                            "protocol": "HTTP/1.1",
+                            "method": "POST",
+                            "uri": "/openai/deployments/gpt-4/chat/completions",
+                            "time": "2023-11-24T03:33:40.39",
+                            "body": json.dumps(
+                                {
+                                    "messages": [
+                                        {"role": "system", "content": ""},
+                                        {"role": "user", "content": "Hi!"},
+                                    ],
+                                    "model": "gpt-4",
+                                    "max_tokens": 2000,
+                                    "stream": True,
+                                    "n": 1,
+                                    "temperature": 0.0,
+                                }
+                            ),
+                        },
+                        "response": {
+                            "status": "200",
+                            "body": 'data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":1700828102,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}]}\n\ndata: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":1700828102,"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"completion_tokens":189,"prompt_tokens":22,"total_tokens":211}}\n\ndata: [DONE]\n',
+                        },
+                    }
+                )
+            },
         ],
     )
     assert response.status_code == 200
     assert write_api_mock.points == [
-        'analytics,deployment=gpt-4,language=undefined,model=gpt-4,project_id=PROJECT-KEY,response_id=chatcmpl-1,title=undefined,topic=TestTopic,upstream=undefined chat_id="chat-1",completion_tokens=189i,number_request_messages=2i,price=0,prompt_tokens=22i,user_hash="undefined" 1692214959997000000'
+        'analytics,deployment=gpt-4,language=undefined,model=gpt-4,project_id=PROJECT-KEY,response_id=chatcmpl-1,title=undefined,topic=TestTopic,upstream=undefined chat_id="chat-1",completion_tokens=189i,number_request_messages=2i,price=0,prompt_tokens=22i,user_hash="undefined" 1692214959997000000',
+        'analytics,deployment=gpt-4,language=undefined,model=gpt-4,project_id=PROJECT-KEY-2,response_id=chatcmpl-2,title=undefined,topic=TestTopic,upstream=undefined chat_id="chat-2",completion_tokens=189i,number_request_messages=2i,price=0,prompt_tokens=22i,user_hash="undefined" 1700796820390000000',
     ]

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,0 +1,64 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from aidial_analytics_realtime.time import parse_time
+
+
+@pytest.mark.parametrize(
+    "time_string, expected",
+    [
+        (
+            "2011-12-03T10:15:30",
+            datetime(2011, 12, 3, 10, 15, 30, tzinfo=timezone.utc),
+        ),
+        (
+            "2011-12-03T10:15:30+01:00",
+            datetime(
+                2011, 12, 3, 10, 15, 30, tzinfo=timezone(timedelta(hours=1))
+            ),
+        ),
+        (
+            "2011-12-03T10:15:30.1",
+            datetime(2011, 12, 3, 10, 15, 30, 100000, tzinfo=timezone.utc),
+        ),
+        (
+            "2011-12-03T10:15:30.12",
+            datetime(2011, 12, 3, 10, 15, 30, 120000, tzinfo=timezone.utc),
+        ),
+        (
+            "2011-12-03T10:15:30.123",
+            datetime(2011, 12, 3, 10, 15, 30, 123000, tzinfo=timezone.utc),
+        ),
+        (
+            "2011-12-03T10:15:30.1234",
+            datetime(2011, 12, 3, 10, 15, 30, 123400, tzinfo=timezone.utc),
+        ),
+        (
+            "2011-12-03T10:15:30.12345",
+            datetime(2011, 12, 3, 10, 15, 30, 123450, tzinfo=timezone.utc),
+        ),
+        (
+            "2011-12-03T10:15:30.123456",
+            datetime(2011, 12, 3, 10, 15, 30, 123456, tzinfo=timezone.utc),
+        ),
+        (
+            "2011-12-03T10:15:30.1234567",
+            datetime(2011, 12, 3, 10, 15, 30, 123456, tzinfo=timezone.utc),
+        ),  # Python's datetime supports up to microsecond precision
+    ],
+)
+def test_parse_time(time_string: str, expected: datetime):
+    assert parse_time(time_string) == expected
+
+
+@pytest.mark.parametrize(
+    "time_string",
+    [
+        "2011-12-03T10:15:30.",  # No fractional part
+        "2011-12-03T10:15:30+01:00[Europe/Paris]",  # Named timezones are not supported
+    ],
+)
+def test_parse_time_should_fail(time_string: str):
+    with pytest.raises(ValueError):
+        parse_time(time_string)


### PR DESCRIPTION
fixes https://github.com/epam/ai-dial-analytics-realtime/issues/14
The datetime.fromisoformat() function from python 3.10, does not support 1 or 2 fractional digits for seconds.
Have to switch to dateutils here, which can handle this format correctly.