### PR TITLE
chore: remove explicit libc6 dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update && \
-    apt-get install -y libc6=2.35-0ubuntu3.5 \
-                       libc-bin=2.35-0ubuntu3.5 \
-                       python3 \
+    apt-get install -y python3 \
                        python3-venv \
                        python3-dev \
                        python3-pip && \
@@ -41,7 +39,7 @@ WORKDIR /
 
 # Install ca-certificates is required for https connection to InfluxDB
 RUN apt-get update && \
-    apt-get install -y libc6=2.35-0ubuntu3.5 libc-bin=2.35-0ubuntu3.5 python3 ca-certificates
+    apt-get install -y python3 ca-certificates
 
 COPY --from=dep-builder --chown=appuser /opt/venv /opt/venv
 COPY --chown=appuser ./aidial_analytics_realtime /aidial_analytics_realtime


### PR DESCRIPTION
Remove explicit libc6 version to avoid updating it every time. The vulnerability which makes us to specify the exact version is already fixed in the base image.