### PR TITLE
fix: Get deployment from deployment field

### DIFF
--- a/aidial_analytics_realtime/app.py
+++ b/aidial_analytics_realtime/app.py
@@ -221,10 +221,10 @@ async def on_log_message(
     trace = message.get("trace", None)
     parent_deployment = message.get("parent_deployment", None)
     execution_path = message.get("execution_path", None)
+    deployment = message.get("deployment", "")
 
     match = re.search(RATE_PATTERN, uri)
     if match:
-        deployment = match.group(1)
         await on_rate_message(
             deployment,
             project_id,
@@ -239,7 +239,6 @@ async def on_log_message(
 
     match = re.search(CHAT_COMPLETION_PATTERN, uri)
     if match:
-        deployment = match.group(1)
         await on_chat_completion_message(
             deployment,
             project_id,
@@ -261,7 +260,6 @@ async def on_log_message(
 
     match = re.search(EMBEDDING_PATTERN, uri)
     if match:
-        deployment = match.group(1)
         await on_embedding_message(
             deployment,
             project_id,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -26,6 +26,7 @@ def test_data_request():
                         "chat": {"id": "chat-1"},
                         "project": {"id": "PROJECT-KEY"},
                         "user": {"id": "", "title": ""},
+                        "deployment": "gpt-4",
                         "request": {
                             "protocol": "HTTP/1.1",
                             "method": "POST",
@@ -59,6 +60,7 @@ def test_data_request():
                         "chat": {"id": "chat-2"},
                         "project": {"id": "PROJECT-KEY-2"},
                         "user": {"id": "", "title": ""},
+                        "deployment": "gpt-4",
                         "request": {
                             "protocol": "HTTP/1.1",
                             "method": "POST",
@@ -113,6 +115,7 @@ def test_data_request_with_new_format():
                         "chat": {"id": "chat-1"},
                         "project": {"id": "PROJECT-KEY"},
                         "user": {"id": "", "title": ""},
+                        "deployment": "gpt-4",
                         "token_usage": {
                             "completion_tokens": 40,
                             "prompt_tokens": 30,
@@ -159,6 +162,7 @@ def test_data_request_with_new_format():
                         "chat": {"id": "chat-2"},
                         "project": {"id": "PROJECT-KEY-2"},
                         "user": {"id": "", "title": ""},
+                        "deployment": "gpt-4",
                         "token_usage": {
                             "completion_tokens": 40,
                             "prompt_tokens": 30,
@@ -223,6 +227,7 @@ def test_rate_response_request():
                         "chat": {"id": "chat-1"},
                         "project": {"id": "PROJECT-KEY"},
                         "user": {"id": "", "title": ""},
+                        "deployment": "gpt-4",
                         "request": {
                             "protocol": "HTTP/1.1",
                             "method": "POST",
@@ -249,6 +254,7 @@ def test_rate_response_request():
                         "chat": {"id": "chat-1"},
                         "project": {"id": "PROJECT-KEY"},
                         "user": {"id": "", "title": ""},
+                        "deployment": "gpt-4",
                         "request": {
                             "protocol": "HTTP/1.1",
                             "method": "POST",

--- a/tests/test_huggingface_model.py
+++ b/tests/test_huggingface_model.py
@@ -26,6 +26,7 @@ def test_data_request():
                         "chat": {"id": "chat-1"},
                         "project": {"id": "PROJECT-KEY"},
                         "user": {"id": "", "title": ""},
+                        "deployment": "gpt-4",
                         "request": {
                             "protocol": "HTTP/1.1",
                             "method": "POST",
@@ -79,6 +80,7 @@ def test_data_request_with_new_format():
                         "chat": {"id": "chat-1"},
                         "project": {"id": "PROJECT-KEY"},
                         "user": {"id": "", "title": ""},
+                        "deployment": "gpt-4",
                         "token_usage": {
                             "completion_tokens": 40,
                             "prompt_tokens": 30,


### PR DESCRIPTION
When interceptors are applied to a deployment, the `deployment ` field in InfluxDB currently contains the value interceptor. However, DIAL Core already stores the correct deployment name in the `deployment `field of the message object.

This PR updates the logic to retrieve the deployment field from message["deployment"] instead of the URL.