### PR TITLE
feat: unified log formats for application and uvicorn

### DIFF
--- a/aidial_analytics_realtime/app.py
+++ b/aidial_analytics_realtime/app.py
@@ -19,21 +19,15 @@ from aidial_analytics_realtime.rates import RatesCalculator
 from aidial_analytics_realtime.time import parse_time
 from aidial_analytics_realtime.topic_model import TopicModel
 from aidial_analytics_realtime.universal_api_utils import merge
+from aidial_analytics_realtime.utils.log_config import configure_loggers, logger
 
 RATE_PATTERN = r"/v1/(.+?)/rate"
 CHAT_COMPLETION_PATTERN = r"/openai/deployments/(.+?)/chat/completions"
 EMBEDDING_PATTERN = r"/openai/deployments/(.+?)/embeddings"
 
-
 app = FastAPI()
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] - %(message)s",
-    handlers=[logging.StreamHandler()],
-)
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+configure_loggers()
 
 
 @app.on_event("startup")

--- a/aidial_analytics_realtime/utils/log_config.py
+++ b/aidial_analytics_realtime/utils/log_config.py
@@ -1,0 +1,39 @@
+import logging
+import sys
+
+from uvicorn.logging import DefaultFormatter
+
+logger = logging.getLogger("app")
+
+
+def configure_loggers():
+    # Delegate uvicorn logs to the root logger
+    # to achieve uniform log formatting
+    for name, log in logging.getLogger().manager.loggerDict.items():
+        if isinstance(log, logging.Logger) and name.startswith("uvicorn"):
+            log.handlers = []
+            log.propagate = True
+
+    # Setting up log levels
+    logger.setLevel(logging.DEBUG)
+
+    # Configuring the root logger
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+
+    root_has_stderr_handler = any(
+        isinstance(handler, logging.StreamHandler)
+        and handler.stream == sys.stderr
+        for handler in root.handlers
+    )
+
+    # Do not override the existing stderr handlers
+    # if they are already configured
+    if not root_has_stderr_handler:
+        formatter = DefaultFormatter(
+            fmt="%(asctime)s [%(levelname)s] - %(message)s"
+        )
+
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(formatter)
+        root.addHandler(handler)


### PR DESCRIPTION
Before:

```
INFO:     Loading environment from '.env'
INFO:     Started server process [61585]
INFO:     Waiting for application startup.
2024-12-12 16:14:24,805 [INFO] - Load pretrained SentenceTransformer: all-mpnet-base-v2
2024-12-12 16:14:27,108 [INFO] - Use pytorch device_name: mps
Batches: 100%|███████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.09it/s]
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:5006 (Press CTRL+C to quit)
2024-12-12 16:14:43,715 [INFO] - Chat completion response length 6
INFO:     127.0.0.1:59632 - "POST /data HTTP/1.1" 200 OK
```

After:

```
INFO:     Loading environment from '.env'
2024-12-12 16:15:16,497 [INFO] - Started server process [69948]
2024-12-12 16:15:16,497 [INFO] - Waiting for application startup.
2024-12-12 16:15:17,504 [INFO] - Load pretrained SentenceTransformer: all-mpnet-base-v2
2024-12-12 16:15:19,690 [INFO] - Use pytorch device_name: mps
Batches: 100%|███████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.30it/s]
2024-12-12 16:15:20,885 [INFO] - Application startup complete.
2024-12-12 16:15:20,897 [INFO] - Uvicorn running on http://127.0.0.1:5006 (Press CTRL+C to quit)
2024-12-12 16:15:27,791 [INFO] - Chat completion response length 6
2024-12-12 16:15:27,791 [INFO] - 127.0.0.1:59682 - "POST /data HTTP/1.1" 200
```