### PR TITLE
fix: ignore `assembled_response` for non-chat-completion endpoints

### DIFF
--- a/aidial_analytics_realtime/app.py
+++ b/aidial_analytics_realtime/app.py
@@ -209,7 +209,6 @@ async def on_log_message(
     parent_deployment = message.get("parent_deployment")
     execution_path = message.get("execution_path")
     deployment = message.get("deployment") or ""
-    response_body = get_assembled_response(message)
 
     if re.search(RATE_PATTERN, uri):
         await on_rate_message(
@@ -225,6 +224,7 @@ async def on_log_message(
         )
 
     elif re.search(CHAT_COMPLETION_PATTERN, uri):
+        response_body = get_assembled_response(message)
         await on_chat_completion_message(
             deployment,
             project_id,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -783,6 +783,7 @@ def test_rate_request():
                                 }
                             ),
                         },
+                        "assembled_response": "",
                         "response": {
                             "status": "200",
                             "body": "",


### PR DESCRIPTION
JSON stored in `assembled_response` is only relevant for `/chat/completions` endpoint, so it should be inspected only by the handler of this endpoint.

Before the fix `/rate` requests failed with JSON parsing error, because DIAL Core sets `assembled_response` to an empty string which is an invalid JSON:

```json
{
  "assembled_response": "",
  "request": {
    "protocol": "HTTP\/1.1",
    "method": "POST",
    "uri": "\/v1\/deployment-id\/rate",
    "time": "2025-02-20T10:20:33.418",
    "body": "{\"rate\":false,\"responseId\":\"chatcmpl-xxxxx\"}"
  },
  "response": {
    "status": "200",
    "body": ""
  }
}
```

The bug was introduced in the fix: https://github.com/epam/ai-dial-analytics-realtime/pull/105