### PR TITLE
chore: Docker: remove redundant security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,16 +47,7 @@ ENV TOPIC_EMBEDDINGS_MODEL="all-mpnet-base-v2"
 
 # Install ca-certificates is required for https connection to InfluxDB
 RUN apt-get update && \
-    apt-get install -y python3 ca-certificates \
-    # Install security fixes
-    gpgv=2.4.4-2ubuntu17.2 \
-    libc6=2.39-0ubuntu8.4 \
-    libcap2=1:2.66-5ubuntu2.2 \
-    libc-bin=2.39-0ubuntu8.4 \
-    libexpat1=2.6.1-2ubuntu0.3 \
-    libgnutls30t64=3.8.3-1.1ubuntu3.3 \
-    liblzma5=5.6.1+really5.4.5-1ubuntu0.2 \
-    libtasn1-6=4.19.0-3ubuntu0.24.04.1
+    apt-get install -y python3 ca-certificates
 
 WORKDIR /app
 


### PR DESCRIPTION
Docker image fails to build because certain packages have been removed:

```
19.76 Package libgnutls30t64 is not available, but is referred to by another package.
19.76 This may mean that the package is missing, has been obsoleted, or
19.76 is only available from another source
19.76 
19.76 Package gpgv is not available, but is referred to by another package.
19.76 This may mean that the package is missing, has been obsoleted, or
19.76 is only available from another source
19.76 
19.76 Package libc-bin is not available, but is referred to by another package.
19.76 This may mean that the package is missing, has been obsoleted, or
19.76 is only available from another source
19.76 However the following packages replace it:
19.76   glibc-tools rpcbind
19.76 
19.77 E: Version '2.4.4-2ubuntu17.2' for 'gpgv' was not found
19.77 E: Version '2.39-0ubuntu8.4' for 'libc6' was not found
19.77 E: Version '2.39-0ubuntu8.4' for 'libc-bin' was not found
19.77 E: Version '3.8.3-1.1ubuntu3.3' for 'libgnutls30t64' was not found
```

To fix the fail, we revert the fix that introduced the dependencies in the first place: https://github.com/epam/ai-dial-analytics-realtime/pull/122

https://github.com/epam/ai-dial-analytics-realtime/blob/release-0.17/Dockerfile#L49-L59

[ubuntu:24.04](https://hub.docker.com/layers/library/ubuntu/24.04/images/sha256-4f1db91d9560cf107b5832c0761364ec64f46777aa4ec637cca3008f287c975e) includes all of the required fixes:

```sh
❯ docker run --rm ubuntu:24.04 \
  dpkg-query -W -f='${binary:Package}\t${Version}\n' \
  gpgv libc6 libcap2 libc-bin libexpat1 libgnutls30t64 liblzma5 libtasn1-6

dpkg-query: no packages found matching libexpat1
gpgv    2.4.4-2ubuntu17.2
libc-bin        2.39-0ubuntu8.4
libc6:arm64     2.39-0ubuntu8.4
libcap2:arm64   1:2.66-5ubuntu2.2
libgnutls30t64:arm64    3.8.3-1.1ubuntu3.3
liblzma5:arm64  5.6.1+really5.4.5-1ubuntu0.2
libtasn1-6:arm64        4.19.0-3ubuntu0.24.04.1
```