### PR TITLE
feat: topic classification feature made optional

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 # https://black.readthedocs.io/en/stable/faq.html#why-are-flake8-s-e203-and-w503-violated
-ignore = E203, W503, E501
+ignore = E203, W503, E501, E704
 exclude =
     .git,
     .tmp,

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Also, following environment valuables can be used to configure the service behav
 |Variable|Default|Description|
 |---|---|---|
 |MODEL_RATES| {} | Specifies per-token price rates for models in JSON format|
-|TOPIC_MODEL| ./topic_model | Specifies the name or path for the topic model. If the model is specified by name, it will be downloaded from, the [Huggingface]( https://huggingface.co/).|
-|TOPIC_EMBEDDINGS_MODEL| None | Specifies the name or path for the embeddings model used with the topic model. If the model is specified by name, it will be downloaded from, the [Huggingface]( https://huggingface.co/). If None, the name will be used from the topic model config.|
+|TOPIC_MODEL||Specifies the name or path for the topic model. If the model is specified by name, it will be downloaded from the [Huggingface]( https://huggingface.co/). When omitted, the topic classification feature is disabled.|
+|TOPIC_EMBEDDINGS_MODEL||Specifies the name or path for the embeddings model used with the topic model. If the model is specified by name, it will be downloaded from the [Huggingface]( https://huggingface.co/). When omitted, the name will be used from the topic model config.|
 |LOG_LEVEL|INFO|The server logging level. Use DEBUG for dev purposes and INFO in prod|
 
 Example of the MODEL_RATES configuration:

--- a/aidial_analytics_realtime/app.py
+++ b/aidial_analytics_realtime/app.py
@@ -25,7 +25,7 @@ from aidial_analytics_realtime.influx_writer import (
 from aidial_analytics_realtime.log_request.message import get_assembled_response
 from aidial_analytics_realtime.rates import RatesCalculator
 from aidial_analytics_realtime.time import parse_time
-from aidial_analytics_realtime.topic_model import TopicModel
+from aidial_analytics_realtime.topic_model import TopicModel, create_topic_model
 from aidial_analytics_realtime.utils.concurrency import cpu_task_executor
 from aidial_analytics_realtime.utils.logging import add_logger_prefix
 from aidial_analytics_realtime.utils.logging import app_logger as logger
@@ -44,7 +44,7 @@ async def lifespan(app: FastAPI):
         async with influx_client:
             app.dependency_overrides[InfluxWriterAsync] = lambda: influx_writer
 
-            topic_model = TopicModel()
+            topic_model = create_topic_model()
             app.dependency_overrides[TopicModel] = lambda: topic_model
 
             rates_calculator = RatesCalculator()

--- a/aidial_analytics_realtime/topic_model.py
+++ b/aidial_analytics_realtime/topic_model.py
@@ -1,4 +1,5 @@
 import os
+from typing import Protocol
 
 from bertopic import BERTopic
 
@@ -9,27 +10,35 @@ from aidial_analytics_realtime.utils.logging import app_logger as logger
 from aidial_analytics_realtime.utils.timer import Timer
 
 
-class TopicModel:
-    def __init__(
-        self,
-        topic_model_name: str | None = None,
-        topic_embeddings_model_name: str | None = None,
-    ):
-        if not topic_model_name:
-            topic_model_name = os.environ.get("TOPIC_MODEL", "./topic_model")
-            topic_embeddings_model_name = os.environ.get(
-                "TOPIC_EMBEDDINGS_MODEL", None
-            )
-        assert topic_model_name is not None
-        self.model = BERTopic.load(
-            topic_model_name, topic_embeddings_model_name
-        )
+class TopicModel(Protocol):
+    async def get_topic_by_text(self, text: str) -> str | None: ...
+
+
+class TopicModelNoOp:
+    async def get_topic_by_text(self, text: str) -> str | None:
+        return None
+
+
+class TopicModelBERT:
+    model: BERTopic
+
+    def __init__(self, model: BERTopic):
+        self.model = model
+
+    @classmethod
+    def create(
+        cls, *, topic_model: str, topic_embeddings_model: str | None
+    ) -> "TopicModelBERT":
+
+        model = BERTopic.load(topic_model, topic_embeddings_model)
 
         # Disable tqdm progress bars on batch encoding
-        self.model.verbose = False
+        model.verbose = False
 
         # Make sure the model is loaded
-        self.model.transform(["test"])
+        model.transform(["test"])
+
+        return cls(model=model)
 
     async def get_topic_by_text(self, text: str) -> str | None:
         try:
@@ -54,3 +63,23 @@ class TopicModel:
                 return topic["GeneratedName"][0][0][0]  # type: ignore
 
             return topic["Name"][0]  # type: ignore
+
+
+def create_topic_model(
+    *,
+    topic_model: str | None = None,
+    topic_embeddings_model: str | None = None,
+) -> TopicModel:
+    topic_model = topic_model or os.getenv("TOPIC_MODEL")
+
+    if topic_model is None:
+        return TopicModelNoOp()
+
+    topic_embeddings_model = topic_embeddings_model or os.getenv(
+        "TOPIC_EMBEDDINGS_MODEL"
+    )
+
+    return TopicModelBERT.create(
+        topic_model=topic_model,
+        topic_embeddings_model=topic_embeddings_model,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ exclude = [
 ]
 
 [tool.pytest.ini_options]
+testpaths = ["tests"]
 markers = [
     "with_external: marks tests may require external resources, like the download models (deselect with '-m \"not with_external\"')",
 ]

--- a/tests/test_huggingface_model.py
+++ b/tests/test_huggingface_model.py
@@ -12,7 +12,7 @@ def test_data_request():
     write_api_mock = InfluxWriterMock()
     app.app.dependency_overrides[app.InfluxWriterAsync] = lambda: write_api_mock
 
-    topic_model = app.TopicModel("davanstrien/chat_topics")
+    topic_model = app.create_topic_model(topic_model="davanstrien/chat_topics")
     app.app.dependency_overrides[app.TopicModel] = lambda: topic_model
 
     client = TestClient(app.app)
@@ -89,7 +89,7 @@ def test_data_request_with_new_format():
     write_api_mock = InfluxWriterMock()
     app.app.dependency_overrides[app.InfluxWriterAsync] = lambda: write_api_mock
 
-    topic_model = app.TopicModel("davanstrien/chat_topics")
+    topic_model = app.create_topic_model(topic_model="davanstrien/chat_topics")
     app.app.dependency_overrides[app.TopicModel] = lambda: topic_model
 
     client = TestClient(app.app)


### PR DESCRIPTION
**Before the fix**: The topic classification feature is always enabled; therefore, topic/embeddings models are always downloaded from HuggingFace and are always being run on the chat completion requests/responses.

**After the fix**: The topic classification could be disabled by unsetting `TOPIC_MODEL` env var - the models won't be downloaded from the HuggingFace.

