### PR TITLE
fix: support disabling topics via empty env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Also, following environment valuables can be used to configure the service behav
 |Variable|Default|Description|
 |---|---|---|
 |MODEL_RATES| {} | Specifies per-token price rates for models in JSON format|
-|TOPIC_MODEL||Specifies the name or path for the topic model. If the model is specified by name, it will be downloaded from the [Huggingface]( https://huggingface.co/). When omitted, the topic classification feature is disabled.|
-|TOPIC_EMBEDDINGS_MODEL||Specifies the name or path for the embeddings model used with the topic model. If the model is specified by name, it will be downloaded from the [Huggingface]( https://huggingface.co/). When omitted, the name will be used from the topic model config.|
+|TOPIC_MODEL||Specifies the name or path for the topic model. If the model is specified by name, it will be downloaded from the [Huggingface]( https://huggingface.co/). When unset or set to an empty string, the topic classification feature is disabled.|
+|TOPIC_EMBEDDINGS_MODEL||Specifies the name or path for the embeddings model used with the topic model. If the model is specified by name, it will be downloaded from the [Huggingface]( https://huggingface.co/). When unset or set to an empty string, the name will be used from the topic model config.|
 |LOG_LEVEL|INFO|The server logging level. Use DEBUG for dev purposes and INFO in prod|
 
 Example of the MODEL_RATES configuration:

--- a/aidial_analytics_realtime/topic_model.py
+++ b/aidial_analytics_realtime/topic_model.py
@@ -70,14 +70,14 @@ def create_topic_model(
     topic_model: str | None = None,
     topic_embeddings_model: str | None = None,
 ) -> TopicModel:
-    topic_model = topic_model or os.getenv("TOPIC_MODEL")
+    topic_model = topic_model or os.getenv("TOPIC_MODEL") or None
 
     if topic_model is None:
         return TopicModelNoOp()
 
     topic_embeddings_model = topic_embeddings_model or os.getenv(
         "TOPIC_EMBEDDINGS_MODEL"
-    )
+    ) or None
 
     return TopicModelBERT.create(
         topic_model=topic_model,

--- a/aidial_analytics_realtime/topic_model.py
+++ b/aidial_analytics_realtime/topic_model.py
@@ -75,9 +75,9 @@ def create_topic_model(
     if topic_model is None:
         return TopicModelNoOp()
 
-    topic_embeddings_model = topic_embeddings_model or os.getenv(
-        "TOPIC_EMBEDDINGS_MODEL"
-    ) or None
+    topic_embeddings_model = (
+        topic_embeddings_model or os.getenv("TOPIC_EMBEDDINGS_MODEL") or None
+    )
 
     return TopicModelBERT.create(
         topic_model=topic_model,


### PR DESCRIPTION
Follow-up of https://github.com/epam/ai-dial-analytics-realtime/pull/155

**Before the fix**: it wasn't possible to disable the topic feature by not setting `TOPIC_MODEL` env var, since it's already set in the `Dockerfile`:

https://github.com/epam/ai-dial-analytics-realtime/blob/release-0.19/Dockerfile#L45-L46

**After the fix**: it's possible to disable the topic feature by setting `TOPIC_MODEL` to an empty string:

`docker run -e TOPIC_MODEL= image_name`