### PR TITLE
fix: error handling made more fine-grained

### DIFF
--- a/aidial_analytics_realtime/app.py
+++ b/aidial_analytics_realtime/app.py
@@ -5,13 +5,15 @@ import logging
 import re
 import sys
 from datetime import datetime
+from typing import Any, List
 
 import aiohttp
 import starlette.requests
 import uvicorn
 from aidial_sdk.telemetry.init import TelemetryConfig, init_telemetry
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
 from aidial_analytics_realtime.analytics import (
     RequestType,
@@ -269,39 +271,36 @@ async def on_log_message(
         logger.warning(f"Unsupported message type: {uri!r}")
 
 
+class DataRequest(BaseModel):
+    __root__: List[Any]
+
+
 @app.post("/data")
 async def on_log_messages(
-    request: Request,
+    data: DataRequest,
     influx_writer: InfluxWriterAsync = Depends(),
     topic_model: TopicModel = Depends(),
     rates_calculator: RatesCalculator = Depends(),
 ):
-
-    data = await request.json()
-
-    n = len(data)
+    messages = data.__root__
+    n = len(messages)
     logger.info(f"number of messages: {n}")
-
-    statuses: list[dict] = []
 
     async with Timer(logger.debug, format="request {elapsed}"):
 
-        async def _task(i: int, message_str: str) -> dict:
+        async def _task(i: int, message: Any) -> dict:
             add_logger_prefix(f"[{i}/{n}]")
 
             async with Timer(logger.debug, format="message {elapsed}"):
                 return await process_message(
-                    json.loads(message_str),
+                    message,
                     influx_writer,
                     topic_model,
                     rates_calculator,
                 )
 
-        statuses = await asyncio.gather(
-            *[
-                _task(i, message["message"])
-                for i, message in enumerate(data, start=1)
-            ]
+        statuses: list[dict] = await asyncio.gather(
+            *[_task(i, message) for i, message in enumerate(messages, start=1)]
         )
 
     if logger.isEnabledFor(logging.DEBUG):
@@ -312,8 +311,12 @@ async def on_log_messages(
     return JSONResponse(content=statuses, status_code=200)
 
 
+class Message(BaseModel):
+    message: str
+
+
 async def process_message(
-    message: dict,
+    request_message: Any,
     influx_writer: InfluxWriterAsync,
     topic_model: TopicModel,
     rates_calculator: RatesCalculator,
@@ -331,8 +334,18 @@ async def process_message(
         return ret
 
     try:
+        message_str = Message.parse_obj(request_message).message
+    except:
+        return _error("invalid request message")
+
+    try:
+        message_dict = json.loads(message_str)
+    except:
+        return _error("invalid JSON in request message")
+
+    try:
         await on_log_message(
-            message, influx_writer, topic_model, rates_calculator
+            message_dict, influx_writer, topic_model, rates_calculator
         )
         logger.info("success")
         return {"status": "success"}

--- a/aidial_analytics_realtime/app.py
+++ b/aidial_analytics_realtime/app.py
@@ -335,12 +335,12 @@ async def process_message(
 
     try:
         message_str = Message.parse_obj(request_message).message
-    except:
+    except Exception:
         return _error("invalid request message")
 
     try:
         message_dict = json.loads(message_str)
-    except:
+    except Exception:
         return _error("invalid JSON in request message")
 
     try:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -889,3 +889,75 @@ def test_chat_completion_invalid_assembled_response(assembled_response):
         r'analytics,core_parent_span_id=undefined,core_span_id=undefined,deployment=gpt-4,execution_path=undefined,language=undefined,model=gpt-4,parent_deployment=undefined,project_id=PROJECT-KEY,response_id=(.+?),title=undefined,topic=ping,trace_id=undefined,upstream=undefined cached_prompt_tokens=0i,chat_id="chat-1",completion_tokens=189i,deployment_price=0.001,number_request_messages=2i,price=0.001,prompt_tokens=22i,user_hash="undefined" 1692214959997000000',
         write_api_mock.points[0],
     )
+
+
+def test_invalid_data_message():
+    write_api_mock = InfluxWriterMock()
+    app.app.dependency_overrides[app.InfluxWriterAsync] = lambda: write_api_mock
+    app.app.dependency_overrides[app.TopicModel] = lambda: TestTopicModel()
+
+    client = TestClient(app.app)
+    response = client.post(
+        "/data",
+        json=[
+            "invalid message",
+            {"message": "invalid message JSON"},
+        ],
+    )
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "status": "error",
+            "error": "1 validation error for Message\n__root__\n  Message expected dict not str (type=type_error)",
+            "reason": "invalid request message",
+        },
+        {
+            "status": "error",
+            "error": "Expecting value: line 1 column 1 (char 0)",
+            "reason": "invalid JSON in request message",
+        },
+    ]
+
+
+def test_invalid_data_request_json():
+    write_api_mock = InfluxWriterMock()
+    app.app.dependency_overrides[app.InfluxWriterAsync] = lambda: write_api_mock
+    app.app.dependency_overrides[app.TopicModel] = lambda: TestTopicModel()
+
+    client = TestClient(app.app, raise_server_exceptions=False)
+    response = client.post(
+        "/data",
+        content="invalid json",
+        headers={"content-type": "application/json"},
+    )
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": [
+            {
+                "type": "json_invalid",
+                "loc": ["body", 0],
+                "msg": "JSON decode error",
+                "input": {},
+                "ctx": {"error": "Expecting value"},
+            }
+        ]
+    }
+
+
+def test_invalid_data_request_type():
+    write_api_mock = InfluxWriterMock()
+    app.app.dependency_overrides[app.InfluxWriterAsync] = lambda: write_api_mock
+    app.app.dependency_overrides[app.TopicModel] = lambda: TestTopicModel()
+
+    client = TestClient(app.app, raise_server_exceptions=False)
+    response = client.post("/data", json={"foo": "bar"})
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": [
+            {
+                "loc": ["body", "__root__"],
+                "msg": "value is not a valid list",
+                "type": "type_error.list",
+            }
+        ]
+    }


### PR DESCRIPTION
Consider the request where the first message is invalid and the second is valid:

```text
POST /data
[
   {"message": "invalid JSON"},
   {"message": "valid JSON string"}
]
```

**Before the fix**: the server fails during JSON parsing of the first message, and returns 500. Also, there is a chance that the second valid message won't even be processed.

**After the fix**: the server returns 200:

```json
[
    {
        "status": "success"
    },
    {
        "status": "error",
        "error": "Expecting value: line 1 column 1 (char 0)",
        "reason": "invalid JSON in request message"
    }
]
```