### PR TITLE
feat: add tracing ids to logs

### DIFF
--- a/aidial_analytics_realtime/app.py
+++ b/aidial_analytics_realtime/app.py
@@ -5,7 +5,7 @@ import logging
 import re
 import sys
 from datetime import datetime
-from typing import Any, List
+from typing import Any
 
 import aiohttp
 import starlette.requests
@@ -13,7 +13,6 @@ import uvicorn
 from aidial_sdk.telemetry.init import TelemetryConfig, init_telemetry
 from fastapi import Depends, FastAPI
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
 
 from aidial_analytics_realtime.analytics import (
     RequestType,
@@ -32,6 +31,11 @@ from aidial_analytics_realtime.utils.concurrency import cpu_task_executor
 from aidial_analytics_realtime.utils.logging import add_logger_prefix
 from aidial_analytics_realtime.utils.logging import app_logger as logger
 from aidial_analytics_realtime.utils.logging import configure_loggers
+from aidial_analytics_realtime.utils.request import (
+    DataRequest,
+    Message,
+    get_tracing_ids,
+)
 from aidial_analytics_realtime.utils.timer import Timer
 
 RATE_PATTERN = r"/v1/(.+?)/rate"
@@ -271,10 +275,6 @@ async def on_log_message(
         logger.warning(f"Unsupported message type: {uri!r}")
 
 
-class DataRequest(BaseModel):
-    __root__: List[Any]
-
-
 @app.post("/data")
 async def on_log_messages(
     data: DataRequest,
@@ -289,7 +289,11 @@ async def on_log_messages(
     async with Timer(logger.debug, format="request {elapsed}"):
 
         async def _task(i: int, message: Any) -> dict:
-            add_logger_prefix(f"[{i}/{n}]")
+            trace_id, span_id = get_tracing_ids(message)
+
+            add_logger_prefix(
+                f"[{i}/{n}] [trace_id={trace_id or 'na'} span_id={span_id or 'na'}]"
+            )
 
             async with Timer(logger.debug, format="message {elapsed}"):
                 return await process_message(
@@ -309,10 +313,6 @@ async def on_log_messages(
     # Returning 200 code even if processing of some messages has failed,
     # since the log broker that sends the messages may decide to retry the failed requests.
     return JSONResponse(content=statuses, status_code=200)
-
-
-class Message(BaseModel):
-    message: str
 
 
 async def process_message(

--- a/aidial_analytics_realtime/utils/request.py
+++ b/aidial_analytics_realtime/utils/request.py
@@ -12,21 +12,24 @@ class Message(BaseModel):
     message: str
 
 
+_TRACE_IDS_RE = re.compile(r"\"(trace_id|core_span_id)\"\s*:\s*\"(\w+)\"")
+
+
 def get_tracing_ids(request_message: Any) -> Tuple[str | None, str | None]:
-    try:
-        message = request_message["message"]
-        if not isinstance(message, str):
-            return None, None
-
-        trace_id = None
-        if m := re.search(r"\"trace_id\"\s*:\s*\"(\w+)\"", message):
-            trace_id = m.group(1)
-
-        span_id = None
-        if m := re.search(r"\"core_span_id\"\s*:\s*\"(\w+)\"", message):
-            span_id = m.group(1)
-
-        return trace_id, span_id
-
-    except Exception:
+    if not isinstance(request_message, dict):
         return None, None
+
+    message = request_message.get("message")
+    if not isinstance(message, str):
+        return None, None
+
+    # The message may be invalid JSON, therefore,
+    # using regexp instead of trying to parse JSON.
+    trace_id, span_id = None, None
+    for name, value in _TRACE_IDS_RE.findall(message):
+        if name == "trace_id":
+            trace_id = value
+        elif name == "core_span_id":
+            span_id = value
+
+    return trace_id, span_id

--- a/aidial_analytics_realtime/utils/request.py
+++ b/aidial_analytics_realtime/utils/request.py
@@ -1,0 +1,32 @@
+import re
+from typing import Any, List, Tuple
+
+from pydantic import BaseModel
+
+
+class DataRequest(BaseModel):
+    __root__: List[Any]
+
+
+class Message(BaseModel):
+    message: str
+
+
+def get_tracing_ids(request_message: Any) -> Tuple[str | None, str | None]:
+    try:
+        message = request_message["message"]
+        if not isinstance(message, str):
+            return None, None
+
+        trace_id = None
+        if m := re.search(r"\"trace_id\"\s*:\s*\"(\w+)\"", message):
+            trace_id = m.group(1)
+
+        span_id = None
+        if m := re.search(r"\"core_span_id\"\s*:\s*\"(\w+)\"", message):
+            span_id = m.group(1)
+
+        return trace_id, span_id
+
+    except Exception:
+        return None, None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ reportIncompatibleMethodOverride = "error"
 exclude = [
     ".git",
     ".nox",
-    ".venv",
+    "**/.venv",
     "**/__pycache__"
 ]
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -471,10 +471,9 @@ def test_embeddings_plain_text(caplog):
         write_api_mock.points[0],
     )
 
-    log_lines = [rec.message for rec in caplog.records]
     assert (
         "[1/1] [trace_id=5dca3d6ed5d22b6ab574f27a6ab5ec14 span_id=9ade2b6fef0a716d] success"
-        in log_lines
+        in caplog.text
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 
 import pytest
@@ -393,7 +394,9 @@ def test_chat_completion_none_content():
     ]
 
 
-def test_embeddings_plain_text():
+def test_embeddings_plain_text(caplog):
+    caplog.set_level(logging.INFO)
+
     write_api_mock: app.InfluxWriterAsync = InfluxWriterMock()
     app.app.dependency_overrides[app.InfluxWriterAsync] = lambda: write_api_mock
     app.app.dependency_overrides[app.TopicModel] = lambda: TestTopicModel()
@@ -466,6 +469,12 @@ def test_embeddings_plain_text():
     assert re.match(
         r'analytics,core_parent_span_id=20e7e64715abbe97,core_span_id=9ade2b6fef0a716d,deployment=text-embedding-3-small,execution_path=undefined/b/c,language=undefined,model=text-embedding-3-small,parent_deployment=assistant,project_id=PROJECT-KEY,response_id=(.+?),title=undefined,topic=fish\\n\\ncat,trace_id=5dca3d6ed5d22b6ab574f27a6ab5ec14,upstream=undefined cached_prompt_tokens=0i,chat_id="chat-1",completion_tokens=0i,deployment_price=0.001,number_request_messages=2i,price=0.001,prompt_tokens=2i,user_hash="undefined" 1692214959997000000',
         write_api_mock.points[0],
+    )
+
+    log_lines = [rec.message for rec in caplog.records]
+    assert (
+        "[1/1] [trace_id=5dca3d6ed5d22b6ab574f27a6ab5ec14 span_id=9ade2b6fef0a716d] success"
+        in log_lines
     )
 
 


### PR DESCRIPTION
It eases the identification of the messages that analytics has failed to process.

Logs before:

```txt
INFO:     | 2025-11-28 18:04:29,648 | 31300 | app | number of messages: 2
INFO:     | 2025-11-28 18:04:29,650 | 31300 | app | [1/2] success
INFO:     | 2025-11-28 18:04:29,654 | 31300 | app | [2/2] success
```

Logs after:

```txt
INFO:     | 2025-11-28 18:04:29,648 | 31300 | app | number of messages: 2
INFO:     | 2025-11-28 18:04:29,650 | 31300 | app | [1/2] [trace_id=5dca3d6ed5d22b6ab574f27a6ab5ec14 span_id=9ade2b6fef0a716d] success
INFO:     | 2025-11-28 18:04:29,654 | 31300 | app | [2/2] [trace_id=5dca3d6ed5d22b6ab574f27a6ab5ec14 span_id=20e7e64715abbe97] success
```