### PR TITLE
feat: introduce INFLUX_DATABASE env var for InfluxDB 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ You need to specify the connection options to the InfluxDB instance using the en
 You can follow the [InfluxDB 3 documentation](https://docs.influxdata.com/influxdb3/core/get-started/) to setup InfluxDB locally and acquire the required configuration parameters.
 
 > [!IMPORTANT]
-> The `INFLUX_DATABASE` variable is introduced in version 0.22.0. For earlier versions set `INFLUX_BUCKET` variable to the target database name and `INFLUX_ORG` variable to any non-empty value (e.g. "ignored") to enable the InfluxDB 3 support.
+> The `INFLUX_DATABASE` variable was introduced in version 0.22.0. For earlier versions set `INFLUX_BUCKET` variable to the target database name and `INFLUX_ORG` variable to any non-empty value (e.g. "ignored") to enable the InfluxDB 3 support.
 
 ### Aggregated Dashboards (Optional)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@
     - [MCP requests](#mcp-requests)
   - [Configuration](#configuration)
     - [Connection to the InfluxDB](#connection-to-the-influxdb)
+      - [InfluxDB 2](#influxdb-2)
     - [Aggregated Dashboards (Optional)](#aggregated-dashboards-optional)
+      - [InfluxDB 3](#influxdb-3)
     - [Other configuration](#other-configuration)
   - [Development](#development)
     - [Development environment](#development-environment)
@@ -127,16 +129,18 @@ Copy `.env.example` to `.env` and customize it for your environment.
 
 ### Connection to the InfluxDB
 
+#### InfluxDB 2
+
 You need to specify the connection options to the InfluxDB instance using the environment variables:
 
 |Variable|Description|
 |---|---|
-|INFLUX_URL|Url to the InfluxDB to write the analytics data|
+|INFLUX_URL|URL to the InfluxDB to write the analytics data|
 |INFLUX_ORG|Name of the InfluxDB organization to write the analytics data|
 |INFLUX_BUCKET|Name of the bucket to write the analytics data|
 |INFLUX_API_TOKEN|InfluxDB API Token|
 
-You can follow the [InfluxDB documentation](https://docs.influxdata.com/influxdb/v2/get-started/) to setup InfluxDB locally and acquire the required configuration parameters.
+You can follow the [InfluxDB 2 documentation](https://docs.influxdata.com/influxdb/v2/get-started/) to setup InfluxDB locally and acquire the required configuration parameters.
 
 ### Aggregated Dashboards (Optional)
 
@@ -145,6 +149,21 @@ This project includes optional **aggregated Grafana dashboards** that visualize 
 To enable these dashboards, you must **manually create the required InfluxDB buckets and tasks**. These steps are **not automated** via Helm and must be applied manually.
 
 See [influxdb/README.md](dashboards/customized/influxdb/README.md) for full instructions.
+
+#### InfluxDB 3
+
+You need to specify the connection options to the InfluxDB instance using the environment variables:
+
+|Variable|Description|
+|---|---|
+|INFLUX_URL|URL to the InfluxDB to write the analytics data|
+|INFLUX_DATABASE|Name of the InfluxDB 3 database to write the analytics data|
+|INFLUX_API_TOKEN|InfluxDB API Token with the write access to the target database|
+
+You can follow the [InfluxDB 3 documentation](https://docs.influxdata.com/influxdb3/core/get-started/) to setup InfluxDB locally and acquire the required configuration parameters.
+
+> [!IMPORTANT]
+> The `INFLUX_DATABASE` variable is introduced in version 0.22.0. For earlier versions set `INFLUX_BUCKET` variable to the target database name and `INFLUX_ORG` variable to any non-empty value (e.g. "ignored") to enable the InfluxDB 3 support.
 
 ### Other configuration
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
   - [Configuration](#configuration)
     - [Connection to the InfluxDB](#connection-to-the-influxdb)
       - [InfluxDB 2](#influxdb-2)
-    - [Aggregated Dashboards (Optional)](#aggregated-dashboards-optional)
       - [InfluxDB 3](#influxdb-3)
+    - [Aggregated Dashboards (Optional)](#aggregated-dashboards-optional)
     - [Other configuration](#other-configuration)
   - [Development](#development)
     - [Development environment](#development-environment)
@@ -142,14 +142,6 @@ You need to specify the connection options to the InfluxDB instance using the en
 
 You can follow the [InfluxDB 2 documentation](https://docs.influxdata.com/influxdb/v2/get-started/) to setup InfluxDB locally and acquire the required configuration parameters.
 
-### Aggregated Dashboards (Optional)
-
-This project includes optional **aggregated Grafana dashboards** that visualize 6-hours and monthly trends.
-
-To enable these dashboards, you must **manually create the required InfluxDB buckets and tasks**. These steps are **not automated** via Helm and must be applied manually.
-
-See [influxdb/README.md](dashboards/customized/influxdb/README.md) for full instructions.
-
 #### InfluxDB 3
 
 You need to specify the connection options to the InfluxDB instance using the environment variables:
@@ -164,6 +156,17 @@ You can follow the [InfluxDB 3 documentation](https://docs.influxdata.com/influx
 
 > [!IMPORTANT]
 > The `INFLUX_DATABASE` variable is introduced in version 0.22.0. For earlier versions set `INFLUX_BUCKET` variable to the target database name and `INFLUX_ORG` variable to any non-empty value (e.g. "ignored") to enable the InfluxDB 3 support.
+
+### Aggregated Dashboards (Optional)
+
+This project includes optional **aggregated Grafana dashboards** that visualize 6-hours and monthly trends.
+
+To enable these dashboards, you must **manually create the required InfluxDB buckets and tasks**. These steps are **not automated** via Helm and must be applied manually.
+
+See [influxdb/README.md](dashboards/customized/influxdb/README.md) for full instructions.
+
+> [!IMPORTANT]
+> Aggregated Dashboards are only supported for InfluxDB 2.
 
 ### Other configuration
 

--- a/aidial_analytics_realtime/influx_writer.py
+++ b/aidial_analytics_realtime/influx_writer.py
@@ -15,13 +15,25 @@ def create_influx_writer() -> Tuple[InfluxDBClientAsync, InfluxWriterAsync]:
     influx_url = get_env("INFLUX_URL")
     influx_api_token = get_env("INFLUX_API_TOKEN")
 
-    if bucket_or_database := os.getenv("INFLUX_BUCKET"):
+    if (bucket := os.getenv("INFLUX_BUCKET")) and (
+        database := os.getenv("INFLUX_DATABASE")
+    ):
+        raise ValueError(
+            "Both INFLUX_BUCKET and INFLUX_DATABASE env variables are set. Only one of them should be set."
+        )
+
+    if bucket:
         # InfluxDB 2 case
         influx_org = get_env("INFLUX_ORG")
-    else:
+        bucket_or_database = bucket
+    elif database:
         # InfluxDB 3 case
         influx_org = "ignored"
-        bucket_or_database = get_env("INFLUX_DATABASE")
+        bucket_or_database = database
+    else:
+        raise ValueError(
+            "Neither INFLUX_BUCKET nor INFLUX_DATABASE env variable is set. Only one of them should be set."
+        )
 
     client = InfluxDBClientAsync(
         url=influx_url, token=influx_api_token, org=influx_org

--- a/aidial_analytics_realtime/influx_writer.py
+++ b/aidial_analytics_realtime/influx_writer.py
@@ -4,6 +4,7 @@ from typing import Awaitable, Callable, Tuple
 from influxdb_client import Point
 from influxdb_client.client.influxdb_client_async import InfluxDBClientAsync
 
+from aidial_analytics_realtime.utils.env import get_env
 from aidial_analytics_realtime.utils.logging import app_logger as logger
 from aidial_analytics_realtime.utils.timer import Timer
 
@@ -11,10 +12,16 @@ InfluxWriterAsync = Callable[[Point], Awaitable[None]]
 
 
 def create_influx_writer() -> Tuple[InfluxDBClientAsync, InfluxWriterAsync]:
-    influx_url = os.environ["INFLUX_URL"]
-    influx_api_token = os.environ.get("INFLUX_API_TOKEN")
-    influx_org = os.environ["INFLUX_ORG"]
-    influx_bucket = os.environ["INFLUX_BUCKET"]
+    influx_url = get_env("INFLUX_URL")
+    influx_api_token = get_env("INFLUX_API_TOKEN")
+
+    if bucket_or_database := os.environ.get("INFLUX_BUCKET"):
+        # InfluxDB 2 case
+        influx_org = get_env("INFLUX_ORG")
+    else:
+        # InfluxDB 3 case
+        influx_org = "ignored"
+        bucket_or_database = get_env("INFLUX_DATABASE")
 
     client = InfluxDBClientAsync(
         url=influx_url, token=influx_api_token, org=influx_org
@@ -23,6 +30,8 @@ def create_influx_writer() -> Tuple[InfluxDBClientAsync, InfluxWriterAsync]:
 
     async def influx_writer_impl(record: Point):
         with Timer(logger.debug, format="influx {elapsed}"):
-            await influx_write_api.write(bucket=influx_bucket, record=record)
+            await influx_write_api.write(
+                bucket=bucket_or_database, record=record
+            )
 
     return client, influx_writer_impl

--- a/aidial_analytics_realtime/influx_writer.py
+++ b/aidial_analytics_realtime/influx_writer.py
@@ -15,7 +15,7 @@ def create_influx_writer() -> Tuple[InfluxDBClientAsync, InfluxWriterAsync]:
     influx_url = get_env("INFLUX_URL")
     influx_api_token = get_env("INFLUX_API_TOKEN")
 
-    if bucket_or_database := os.environ.get("INFLUX_BUCKET"):
+    if bucket_or_database := os.getenv("INFLUX_BUCKET"):
         # InfluxDB 2 case
         influx_org = get_env("INFLUX_ORG")
     else:

--- a/aidial_analytics_realtime/utils/env.py
+++ b/aidial_analytics_realtime/utils/env.py
@@ -1,0 +1,8 @@
+import os
+from typing import Optional
+
+
+def get_env(name: str, err_msg: Optional[str] = None) -> str:
+    if (val := os.getenv(name)) is not None:
+        return val
+    raise Exception(err_msg or f"{name} env variable is not set")

--- a/aidial_analytics_realtime/utils/env.py
+++ b/aidial_analytics_realtime/utils/env.py
@@ -1,8 +1,7 @@
 import os
-from typing import Optional
 
 
-def get_env(name: str, err_msg: Optional[str] = None) -> str:
+def get_env(name: str) -> str:
     if (val := os.getenv(name)) is not None:
         return val
-    raise Exception(err_msg or f"{name} env variable is not set")
+    raise Exception(f"{name} env variable is not set")


### PR DESCRIPTION
Partially addresses #209 by introducing `INFLUX_DATABASE` env var to ease the configuration of the analytics service for InfluxDB 3.