### PR TITLE
chore: add trigger to dial-analytics-realtime-test on dev

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - environment-name: "development"
+          - environment-name: "development-influxdb2"
             gitlab-project-id: "3018"
-          - environment-name: "development-test"
+          - environment-name: "development-influxdb3"
             gitlab-project-id: "3174"
 
     name: Deploy to ${{ matrix.environment-name }}

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -14,9 +14,20 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.registry_package.package_version.container_metadata.tag.name == 'development' ||
       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'development')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - environment-name: "development"
+            gitlab-project-id: "3018"
+          - environment-name: "development-test"
+            gitlab-project-id: "3174"
+
+    name: Deploy to ${{ matrix.environment-name }}
     uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.0.1
     with:
-      gitlab-project-id: '3018'
+      gitlab-project-id: ${{ matrix.gitlab-project-id }}
+      environment-name: ${{ matrix.environment-name }}
     secrets:
       DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
       DEPLOY_ACCESS_TOKEN: ${{ secrets.DEPLOY_ACCESS_TOKEN }}


### PR DESCRIPTION
Description of changes:

- Updated Deploy development GitHub Actions workflow to support deployments to multiple GitLab projects using a matrix strategy.
- Added deployment targets for:
- development-influxdb2 (gitlab-project-id: 3018)
- development-influxdb3 (dial-analytics-realtime-test) (gitlab-project-id: 3174)
- Added dynamic job naming via environment-name.
- Replaced hardcoded gitlab-project-id with matrix-based configuration to simplify scaling and maintenance of deployment targets.
- Enabled parallel execution of deployment jobs with fail-fast: false.