### PR TITLE
fix: avoid UnboundLocalError when only INFLUX_DATABASE is set

### DIFF
--- a/aidial_analytics_realtime/influx_writer.py
+++ b/aidial_analytics_realtime/influx_writer.py
@@ -15,9 +15,10 @@ def create_influx_writer() -> tuple[InfluxDBClientAsync, InfluxWriterAsync]:
     influx_url = get_env("INFLUX_URL")
     influx_api_token = get_env("INFLUX_API_TOKEN")
 
-    if (bucket := os.getenv("INFLUX_BUCKET")) and (
-        database := os.getenv("INFLUX_DATABASE")
-    ):
+    bucket = os.getenv("INFLUX_BUCKET")
+    database = os.getenv("INFLUX_DATABASE")
+
+    if bucket and database:
         raise ValueError(
             "Both INFLUX_BUCKET and INFLUX_DATABASE env variables are set. "
             "Only one of them should be set."


### PR DESCRIPTION
### Applicable issues

- fixes #267

### Description of changes

Read `INFLUX_BUCKET` and `INFLUX_DATABASE` before validation. Walrus `and` short-circuit left `database` unassigned when only `INFLUX_DATABASE` was set, so the service failed on startup.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.