### PR TITLE
chore: bump starlette to 1.3.1 and add httpx2 for tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -813,6 +813,28 @@ socks = ["socksio (==1.*)"]
 trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
+name = "httpcore2"
+version = "2.4.0"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.10"
+groups = ["test"]
+files = [
+    {file = "httpcore2-2.4.0-py3-none-any.whl", hash = "sha256:5218779da5d6e3c2013ac706121abfb3815d450e0613495c0de50264dce58242"},
+    {file = "httpcore2-2.4.0.tar.gz", hash = "sha256:3093a8ab8980d9f910b9cb4351df9186a0ad2350a6284a9107ac9a362a584422"},
+]
+
+[package.dependencies]
+h11 = ">=0.16"
+truststore = ">=0.10"
+
+[package.extras]
+asyncio = ["anyio (>=4.5.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
 name = "httpx"
 version = "0.25.2"
 description = "The next generation HTTP client."
@@ -836,6 +858,32 @@ brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi 
 cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
+
+[[package]]
+name = "httpx2"
+version = "2.4.0"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.10"
+groups = ["test"]
+files = [
+    {file = "httpx2-2.4.0-py3-none-any.whl", hash = "sha256:425acd99297829599decf6701386dd84db3542597d36d3e2e4def930ecd57fd9"},
+    {file = "httpx2-2.4.0.tar.gz", hash = "sha256:32e0734b61eb0824b3f56a9e98d6d92d381a3ef12c0045aa917ee63df6c411ef"},
+]
+
+[package.dependencies]
+anyio = "*"
+httpcore2 = "2.4.0"
+idna = ">=3.18"
+truststore = ">=0.10"
+typing-extensions = {version = ">=4.5.0", markers = "python_version < \"3.13\""}
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<16)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0) ; python_version <= \"3.13\""]
 
 [[package]]
 name = "huggingface-hub"
@@ -890,14 +938,14 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "test"]
 files = [
-    {file = "idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"},
-    {file = "idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"},
+    {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
+    {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
 ]
 
 [package.extras]
@@ -3019,14 +3067,14 @@ files = [
 
 [[package]]
 name = "starlette"
-version = "1.0.1"
+version = "1.3.1"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd"},
-    {file = "starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f"},
+    {file = "starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"},
+    {file = "starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0"},
 ]
 
 [package.dependencies]
@@ -3034,7 +3082,7 @@ anyio = ">=3.6.2,<5"
 typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
-full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+full = ["httpx (>=0.27.0,<0.29.0)", "httpx2 (>=2.0.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "sympy"
@@ -3376,6 +3424,18 @@ files = [
 build = ["cmake (>=3.20,<4.0)", "lit"]
 tests = ["autopep8", "isort", "llnl-hatchet", "numpy", "pytest", "pytest-forked", "pytest-xdist", "scipy (>=1.7.1)"]
 tutorials = ["matplotlib", "pandas", "tabulate"]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+description = "Verify certificates using native system trust stores"
+optional = false
+python-versions = ">=3.10"
+groups = ["test"]
+files = [
+    {file = "truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"},
+    {file = "truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"},
+]
 
 [[package]]
 name = "typer"
@@ -3725,4 +3785,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "05a804c7b0b44d7fedade3b5cf1685b4188f9ade0e70f3929b3f31ab9b3f5ef2"
+content-hash = "e27ca278ccc30729a54c73c8c1d7c6da98a28fd3f2e6dfb1e9b98485660e05c9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ package-mode = false
 [tool.poetry.dependencies]
 aiohttp = "3.14.0"
 fastapi = "0.135.1"
+starlette = ">=1.3.1,<2"
 uvicorn = "0.22.0"
 influxdb-client = "1.37.0"
 langid = "1.1.6"
@@ -55,6 +56,7 @@ priority = "explicit"
 [tool.poetry.group.test.dependencies]
 pytest = "^9.0.3"
 httpx = "^0.25.2"
+httpx2 = "^2.0.0"
 pytest-env = "1.1.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
+from typing import cast
 from unittest.mock import patch
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -44,5 +46,8 @@ def client(influx, language_classifier, topic_model) -> Client:
     app.app.dependency_overrides[app.InfluxWriterAsync] = lambda: influx  # type: ignore
     app.app.dependency_overrides[app.TopicModel] = lambda: topic_model
     return Client(
-        http_client=TestClient(app.app, raise_server_exceptions=False)
+        http_client=cast(
+            httpx.Client,
+            TestClient(app.app, raise_server_exceptions=False),
+        )
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
-from typing import cast
 from unittest.mock import patch
 
-import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -46,8 +44,5 @@ def client(influx, language_classifier, topic_model) -> Client:
     app.app.dependency_overrides[app.InfluxWriterAsync] = lambda: influx  # type: ignore
     app.app.dependency_overrides[app.TopicModel] = lambda: topic_model
     return Client(
-        http_client=cast(
-            httpx.Client,
-            TestClient(app.app, raise_server_exceptions=False),
-        )
+        http_client=TestClient(app.app, raise_server_exceptions=False)
     )

--- a/tests/utils/client.py
+++ b/tests/utils/client.py
@@ -1,18 +1,26 @@
 import json
-from typing import Any
+from typing import Any, Protocol
 
-import httpx
+
+class HttpResponse(Protocol):
+    status_code: int
+
+    def json(self) -> Any: ...
+
+
+class HttpClient(Protocol):
+    def post(self, url: str, *, json: Any) -> HttpResponse: ...
 
 
 class Client:
-    http_client: httpx.Client
+    http_client: HttpClient
 
-    def __init__(self, http_client: httpx.Client) -> None:
+    def __init__(self, http_client: HttpClient) -> None:
         self.http_client = http_client
 
-    def post_json(self, payload: Any) -> httpx.Response:
+    def post_json(self, payload: Any) -> HttpResponse:
         return self.http_client.post(url="/data", json=payload)
 
-    def __call__(self, *messages: dict) -> httpx.Response:
+    def __call__(self, *messages: dict) -> HttpResponse:
         payload = [{"message": json.dumps(m)} for m in messages]
         return self.post_json(payload)

--- a/tests/utils/client.py
+++ b/tests/utils/client.py
@@ -1,26 +1,18 @@
 import json
-from typing import Any, Protocol
+from typing import Any
 
-
-class HttpResponse(Protocol):
-    status_code: int
-
-    def json(self) -> Any: ...
-
-
-class HttpClient(Protocol):
-    def post(self, url: str, *, json: Any) -> HttpResponse: ...
+import httpx2
 
 
 class Client:
-    http_client: HttpClient
+    http_client: httpx2.Client
 
-    def __init__(self, http_client: HttpClient) -> None:
+    def __init__(self, http_client: httpx2.Client) -> None:
         self.http_client = http_client
 
-    def post_json(self, payload: Any) -> HttpResponse:
+    def post_json(self, payload: Any) -> httpx2.Response:
         return self.http_client.post(url="/data", json=payload)
 
-    def __call__(self, *messages: dict) -> HttpResponse:
+    def __call__(self, *messages: dict) -> httpx2.Response:
         payload = [{"message": json.dumps(m)} for m in messages]
         return self.post_json(payload)


### PR DESCRIPTION
### Applicable issues

- fixes #

### Description of changes

Pin `starlette` to `>=1.3.1` to clear HIGH CVEs flagged by Trivy in `docker_build`.
Add `httpx2` test dependency and adjust `conftest.py` typing for Starlette 1.3 `TestClient`.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.