### PR TITLE
ci(deps): bump epam/ai-dial-ci from 4.10.0 to 4.11.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,8 @@ updates:
       day: "wednesday"
       time: "09:00"
     commit-message:
-      # Prefix all commit messages with "chore: "
-      prefix: "chore"
+      prefix: "ci"
+      include: scope
     groups:
       ai-dial-ci:
         applies-to: version-updates

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,10 +7,4 @@
 
 <!-- Please explain the changes you made right below this line. -->
 
-### Checklist
-
-<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
-
-- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
-
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/workflows/cleanup-untagged-images.yml
+++ b/.github/workflows/cleanup-untagged-images.yml
@@ -14,3 +14,6 @@ jobs:
       - uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           delete-untagged: true
+          delete-ghost-images: true # Delete indexes with no manifests
+          delete-partial-images: true # Delete indexes which refer to at least one non-existent manifest
+          delete-orphaned-images: true # Delete dangling referrers, e.g. SBOMs, signatures, etc. that refer to non-existent digest

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -15,6 +15,7 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       - name: Approve PR
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -24,7 +24,7 @@ jobs:
             gitlab-project-id: "3174"
 
     name: Deploy to ${{ matrix.environment-name }}
-    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.10.0
+    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.11.0
     with:
       gitlab-project-id: ${{ matrix.gitlab-project-id }}
       environment-name: ${{ matrix.environment-name }}

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   pr-title-check:
-    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.10.0
+    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.11.0
     secrets:
       ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/python_docker_pr.yml@4.10.0
+    uses: epam/ai-dial-ci/.github/workflows/python_docker_pr.yml@4.11.0
     secrets: inherit
     with:
       poetry-version: "2.1.1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/python_docker_release.yml@4.10.0
+    uses: epam/ai-dial-ci/.github/workflows/python_docker_release.yml@4.11.0
     with:
       promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
       poetry-version: "2.1.1"

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -5,7 +5,9 @@ on:
 jobs:
   slashCommandDispatch:
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request }}
+    if: |
+      github.event.issue.pull_request &&
+      github.event.issue.state == 'open'
     steps:
       - name: Slash Command Dispatch
         id: scd

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,14 +1,14 @@
 ---
+analyzer:
+  skip_excluded: true
 excludes:
   scopes:
   - pattern: "dev"
     reason: "DEV_DEPENDENCY_OF"
     comment: "Packages for development only."
+  - pattern: "lint"
+    reason: "DEV_DEPENDENCY_OF"
+    comment: "Packages for static code analysis only."
   - pattern: "test"
     reason: "TEST_DEPENDENCY_OF"
     comment: "Packages for testing only."
-resolutions:
-  rule_violations:
-    - message: ".*PyPI::(opentelemetry|networkx|scipy|fastapi|starlette|typing-extensions|setuptools|sentencepiece|aidial-sdk|scikit-learn|anyio|pillow|urllib3|httpx|httpcore|idna|typer|pygments|annotated-types|typing-inspection|regex).*"
-      reason: "CANT_FIX_EXCEPTION"
-      comment: "ORT cannot pick up license information for these packages with no clear license metadata"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.12,<3.13"
 dynamic = ["dependencies"]
 
 [project.urls]
-Homepage = "https://epam-rail.com"
+Homepage = "https://dialx.ai"
 Repository = "https://github.com/epam/ai-dial-analytics-realtime"
 
 [tool.poetry]


### PR DESCRIPTION
### Description of changes

- bump epam/ai-dial-ci from `4.10.0` to `4.11.0`
- align workflows with recommended configuration; this delivers minor fixes
- drop ORT resolutions in favor of shared curations in [ai-dial-ort-config](https://github.com/epam/ai-dial-ort-config/)
- update homepage URL in project metadata